### PR TITLE
Fix file missing from source-tarball

### DIFF
--- a/servant-auth-hmac.cabal
+++ b/servant-auth-hmac.cabal
@@ -52,6 +52,7 @@ library
 executable example
   hs-source-dirs:     example/server
   main-is:            Example.hs
+  other-modules:      AuthAPI
   build-depends: base
                , aeson
                , blaze-html


### PR DESCRIPTION
This is mostly a problem for older `cabal` versions; new `cabal` versions will only attempt to build the library component